### PR TITLE
update - added support for token

### DIFF
--- a/src/AwsMskIamSaslSigner.php
+++ b/src/AwsMskIamSaslSigner.php
@@ -14,7 +14,7 @@ class AwsMskIamSaslSigner
         private readonly string $region,
         private readonly string $accessKeyId,
         private readonly string $secretAccessKey,
-        private readonly ?string $sessionToken = null,
+        private readonly ?string $sessionToken = null
     ) {
     }
 

--- a/src/AwsMskIamSaslSigner.php
+++ b/src/AwsMskIamSaslSigner.php
@@ -8,12 +8,13 @@ use GuzzleHttp\Psr7;
 
 class AwsMskIamSaslSigner
 {
-    const VERSION = '1.0.0';
+    public const VERSION = '1.0.0';
 
     public function __construct(
         private readonly string $region,
         private readonly string $accessKeyId,
-        private readonly string $secretAccessKey
+        private readonly string $secretAccessKey,
+        private readonly ?string $sessionToken = null,
     ) {
     }
 
@@ -21,7 +22,7 @@ class AwsMskIamSaslSigner
     {
         $signatureV4 = new SignatureV4('kafka-cluster', $this->region);
 
-        $credentials = new Credentials($this->accessKeyId, $this->secretAccessKey);
+        $credentials = new Credentials($this->accessKeyId, $this->secretAccessKey, $this->sessionToken);
 
         $host = "kafka.{$this->region}.amazonaws.com";
 

--- a/tests/AwsMskIamSaslSignerTest.php
+++ b/tests/AwsMskIamSaslSignerTest.php
@@ -14,3 +14,24 @@ it('can generateToken', function () {
     expect($token['token'])->toBeString();
     expect($token['expiryTime'])->toBeInt();
 });
+
+it('includes session token when provided', function () {
+    $sessionToken = 'FAKE_SESSION_TOKEN_ABC123';
+
+    $signer = new AwsMskIamSaslSigner(
+        'ap-southeast-1',
+        'testAccessKeyId',
+        'testSecretAccessKey',
+        $sessionToken,
+    );
+
+    $token = $signer->generateToken();
+
+    // Decode the returned token back into a URL to inspect the query string
+    $decodedUrl = base64_decode(strtr($token['token'], '-_', '+/'));
+    $parts      = parse_url($decodedUrl);
+    parse_str($parts['query'] ?? '', $query);
+
+    expect($query)->toHaveKey('X-Amz-Security-Token');
+    expect($query['X-Amz-Security-Token'])->toBe($sessionToken);
+});


### PR DESCRIPTION
This PR adds optional support for AWS session tokens to the AwsMskIamSaslSigner, enabling the library to work correctly with temporary AWS credentials such as those provided by:

EKS IRSA (IAM Roles for Service Accounts)

STS AssumeRole / WebIdentity tokens

Any SDK-based short-lived credential source

At the moment, the signer only accepts accessKeyId + secretAccessKey and cannot use the sessionToken.
This causes MSK to reject the generated OAUTHBEARER token when used from EKS IRSA with:

`SASL authentication error: Invalid authentication payload`


because the SigV4 presigned request is missing the required
X-Amz-Security-Token parameter.

This PR fully resolves that problem.